### PR TITLE
A few fixes to chip away at the compiler warnings

### DIFF
--- a/AnimatedCursor.cpp
+++ b/AnimatedCursor.cpp
@@ -105,7 +105,7 @@ void CAnimatedCursor::Render()
 void CAnimatedCursor::SetIcons(CursorType type, std::list<CDXBitmap*> icons)
 {
 	_type = type;
-	_iconCount = icons.size();
+	_iconCount = static_cast<int>(icons.size());
 	_ppIcons = new CDXBitmap * [_iconCount];
 	for (int i = 0; i < _iconCount; i++)
 	{

--- a/BIC.h
+++ b/BIC.h
@@ -13,9 +13,9 @@ public:
 protected:
 	virtual BOOL DecodeFrame();
 
-	int _embeddedAudioSize;
-	int _firstAudioFrame;
-	int _chunkTest;
+	int _embeddedAudioSize{};
+	int _firstAudioFrame{};
+	int _chunkTest{};
 
 	int ProcessBICFrame(int offset, int chunkSize);
 

--- a/Configuration.cpp
+++ b/Configuration.cpp
@@ -54,7 +54,7 @@ CConfiguration::CConfiguration(LPWSTR gameName)
 		AnisotropicFilter = ((flags & CONFIG_FLAGS_ANISOTROPICFILTER) == 0);	// Inverted
 
 		MIDIDeviceId = GetRegistryInt(hk, L"MIDIDeviceId", -1);
-		FontScale = max(1.0, min(GetRegistryFloat(hk, L"FontScale", 1.0f), 3.0));
+		FontScale = max(1.0f, min(GetRegistryFloat(hk, L"FontScale", 1.0f), 3.0f));
 		Volume = max(0, min(GetRegistryInt(hk, L"Volume", 100), 100));
 		MIDIVolume = max(0, min(GetRegistryInt(hk, L"MIDIVolume", 100), 100));
 

--- a/Configuration.cpp
+++ b/Configuration.cpp
@@ -69,7 +69,7 @@ CConfiguration::CConfiguration(LPWSTR gameName)
 		int currentMode = -1;
 		int currentModeDiff = 1000000000;
 
-		for (int m = 0; m < pAdapter->_numModes; m++)
+		for (int m = 0; m < static_cast<int>(pAdapter->_numModes); m++)
 		{
 			if (pAdapter->_displayModeList[m].Width >= 640 && pAdapter->_displayModeList[m].Height >= 480)
 			{

--- a/DXButton.h
+++ b/DXButton.h
@@ -31,7 +31,7 @@ public:
 
 protected:
 	void(*_clicked)(LPVOID data);
-	LPVOID _data;
+	LPVOID _data{};
 
 	static CTexture _texBackground;
 	static CTexture _texMouseOver;

--- a/DXFrame.h
+++ b/DXFrame.h
@@ -29,6 +29,6 @@ public:
 protected:
 	CDXFrame() {}
 	static CTexture _texBackground;
-	CDXText* _pText;
-	int _textW;
+	CDXText* _pText{};
+	int _textW{};
 };

--- a/Elevation.h
+++ b/Elevation.h
@@ -1,6 +1,6 @@
 #pragma once
 
-typedef struct Elevation
+struct Elevation
 {
 	int Type;
 	int Id;

--- a/FileMap.h
+++ b/FileMap.h
@@ -1,6 +1,6 @@
 #pragma once
 
-typedef struct FileMap
+struct FileMap
 {
 	int File;
 	int Entry;

--- a/Gamepad.cpp
+++ b/Gamepad.cpp
@@ -132,7 +132,7 @@ void CGamepad::Update()
 		{
 			if (SUCCEEDED(_pDevice->GetDeviceData(sizeof(DIDEVICEOBJECTDATA), data, &dwItemCount, 0)))
 			{
-				for (int i = 0; i < dwItemCount; i++)
+				for (int i = 0; i < static_cast<int>(dwItemCount); i++)
 				{
 					InputSource source = InputSource::Unknown;
 					int dwData = data[i].dwData;

--- a/Globals.cpp
+++ b/Globals.cpp
@@ -1,6 +1,6 @@
 #include "DirectX.h"
 #include "AnimBase.h"
-#include <list>"
+#include <list>
 #include "Caption.h"
 #include "GameBase.h"
 #include "ModuleBase.h"

--- a/InventoryModule.cpp
+++ b/InventoryModule.cpp
@@ -621,7 +621,7 @@ void CInventoryModule::ScrollDown(LPVOID data)
 
 void CInventoryModule::UpdateButtons()
 {
-	BOOL tooManyLines = ((_visibleLineCount - _lineCount) < 0);
+	bool tooManyLines = ((_visibleLineCount - _lineCount) < 0);
 	_pBtnUp->SetEnabled(tooManyLines && _lineAdjustment != (_lineCount - _visibleLineCount));
 	if (!_pBtnUp->GetEnabled())
 	{

--- a/InventoryModule.cpp
+++ b/InventoryModule.cpp
@@ -391,7 +391,7 @@ void CInventoryModule::OnExamine(LPVOID data)
 		pDisplayCaptions = pAddCaptions;
 		pAddCaptions = pOld;
 		ClearCaptions(pOld);
-		Rect rect{ 0.0f, 0.0f, 1000.0f, _limitedRect.right - _limitedRect.left };
+		Rect rect{ 0.0f, 0.0f, 1000.0f, static_cast<float>(_limitedRect.right - _limitedRect.left)};
 		_text.SetText(pDesc, rect);
 		_lineCount = _text.Lines();
 		_lineAdjustment = max(0, min(_lineCount - _visibleLineCount, _lineCount));

--- a/InventoryModule.cpp
+++ b/InventoryModule.cpp
@@ -80,6 +80,7 @@ CInventoryModule::CInventoryModule() : CModuleBase(ModuleType::Inventory)
 	ExamineItemOnResume = -1;
 
 	_text.SetColours(0xff000000, 0xff00c300, 0xff24ff00, 0xff000000);
+	_fullRect = { 0,0,0,0 };
 }
 
 CInventoryModule::~CInventoryModule()

--- a/MainMenuModule.cpp
+++ b/MainMenuModule.cpp
@@ -206,7 +206,7 @@ void CMainMenuModule::ConfigPreviousResolution(LPVOID data)
 
 void CMainMenuModule::ConfigNextResolution(LPVOID data)
 {
-	if (pConfig->pAdapter != NULL && cfgMode < (pConfig->pAdapter->_numModes - 1))
+	if (pConfig->pAdapter != NULL && cfgMode < (static_cast<int>(pConfig->pAdapter->_numModes) - 1))
 	{
 		cfgMode++;
 		cfgWidth = pConfig->pAdapter->_displayModeList[cfgMode].Width;
@@ -602,7 +602,7 @@ void CMainMenuModule::SaveSetup()
 		nameLength--;
 	}
 
-	for (unsigned int i = 0; i < 6; i++)
+	for (int i = 0; i < 6; i++)
 	{
 		info.FileName += (WCHAR)((i < nameLength) ? CurrentGameInfo.Player.at(i) : '_');
 	}

--- a/StartupPosition.h
+++ b/StartupPosition.h
@@ -1,6 +1,6 @@
 #pragma once
 
-typedef struct StartupPosition
+struct StartupPosition
 {
 	float X;
 	float Y;

--- a/UAKMColonelsComputerModule.cpp
+++ b/UAKMColonelsComputerModule.cpp
@@ -95,7 +95,7 @@ void CUAKMColonelsComputerModule::Render()
 	else if (_currentPage == 1)
 	{
 		int requiredDelta = (_currentFrame > 0) ? _colonelsComputerAnimData[4 * _currentFrame + 3] * TIMER_SCALE : 0;
-		if (delta >= requiredDelta)
+		if (static_cast<int>(delta) >= requiredDelta)
 		{
 			int img = _colonelsComputerAnimData[4 * _currentFrame];
 			int y1 = _colonelsComputerAnimData[4 * _currentFrame + 1];


### PR DESCRIPTION
I've addressed a few of the compiler warnings. I believe it's possible to turn off warnings for external code, so ultimately it may be possible to enable /WX to treat any warnings as errors. I've tried to make a best guess in the cases below at the correct cast/initialisation to use. It may be possible to rewrite some of these to ultimately remove the casts, but for now they should be functionally the same while documenting that a conversion is taking place.

Contributes to fixing #2 