### PR TITLE
Add a few wrappers to silence warnings in noisy DirectX system headers

### DIFF
--- a/AnimBase.h
+++ b/AnimBase.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "Globals.h"
-#include <d3d11.h>
+#include "D3D11-NoWarn.h"
 #include <dsound.h>
 #include "LZ.h"
 #include <xaudio2.h>

--- a/ConstantBuffers.h
+++ b/ConstantBuffers.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "DirectX.h"
-#include <D3D11.h>
+#include "D3D11-NoWarn.h"
 //#include <D3DX10math.h>
 
 class CConstantBuffers

--- a/D3D11-NoWarn.h
+++ b/D3D11-NoWarn.h
@@ -1,0 +1,9 @@
+// This file includes D3D11.h while disabling warnings
+// in order to cut down on unnecessary backgound noise
+// during compilation
+
+#pragma once
+
+#pragma warning(push,0)
+#include <D3D11.h>
+#pragma warning(pop)

--- a/D3DX10-NoWarn.h
+++ b/D3DX10-NoWarn.h
@@ -1,0 +1,9 @@
+// This file includes D3DX10.h while disabling warnings
+// in order to cut down on unnecessary backgound noise
+// during compilation
+
+#pragma once
+
+#pragma warning(push, 0)
+#include <D3DX10.h>
+#pragma warning(pop)

--- a/D3DX11-NoWarn.h
+++ b/D3DX11-NoWarn.h
@@ -1,0 +1,9 @@
+// This file includes D3DX11.h while disabling warnings
+// in order to cut down on unnecessary backgound noise
+// during compilation
+
+#pragma once
+
+#pragma warning(push,0)
+#include <D3DX11.h>
+#pragma warning(pop)

--- a/DXBase.h
+++ b/DXBase.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <D3D11.h>
-#include <d3dx11.h>
+#include "D3D11-NoWarn.h"
+#include "D3DX11-NoWarn.h"
 #include "Structs.h"
 #include <atlbase.h>
 #include <DirectXMath.h>

--- a/DXControl.cpp
+++ b/DXControl.cpp
@@ -1,5 +1,5 @@
 #include "DXControl.h"
-#include <D3DX11.h>
+#include "D3DX11-NoWarn.h"
 #include "Utilities.h"
 
 using namespace DirectX::PackedVector;

--- a/DXMultiColouredText.h
+++ b/DXMultiColouredText.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "DXText.h"
-#include <D3D11.h>
+#include "D3D11-NoWarn.h"
 #include "DirectX.h"
 
 class CDXMultiColouredText : public CDXText

--- a/DXText.h
+++ b/DXText.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <D3D11.h>
+#include "D3D11-NoWarn.h"
 #include "DirectX.h"
 
 class CDXText : public CDXBase

--- a/FullScreenModule.h
+++ b/FullScreenModule.h
@@ -2,7 +2,7 @@
 
 #include "ModuleBase.h"
 #include <unordered_map>
-#include <d3d11.h>
+#include "D3D11-NoWarn.h"
 #include "Texture.h"
 
 class CFullScreenModule : public CModuleBase

--- a/Gamepad.h
+++ b/Gamepad.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <dinput.h>
+#include "dinput-NoWarn.h"
 #include <list>
 #include "Utilities.h"
 #include <string>

--- a/InventoryModule.h
+++ b/InventoryModule.h
@@ -2,7 +2,7 @@
 
 #include "ModuleBase.h"
 #include <list>
-#include <D3D11.h>
+#include "D3D11-NoWarn.h"
 #include "DXButton.h"
 #include "AnimBase.h"
 #include "DXImageButton.h"

--- a/Location.h
+++ b/Location.h
@@ -5,7 +5,7 @@
 #include <vector>
 #include "LZ.h"
 #include "Texture.h"
-#include <d3d11.h>
+#include "D3D11-NoWarn.h"
 #include <unordered_map>
 #include "DXText.h"
 #include "Mutex.h"

--- a/ModuleBase.h
+++ b/ModuleBase.h
@@ -2,8 +2,8 @@
 
 #include <Windows.h>
 #include "Map.h"
-#include <D3D11.h>
-#include <D3DX11.h>
+#include "D3D11-NoWarn.h"
+#include "D3DX11-NoWarn.h"
 #include <DirectXPackedVector.h>
 #include "InputMapping.h"
 

--- a/ResumeGameModule.h
+++ b/ResumeGameModule.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "ModuleBase.h"
-#include <D3D11.h>
+#include "D3D11-NoWarn.h"
 #include "DXButton.h"
 #include "AnimBase.h"
 #include "DXScreen.h"

--- a/Shaders.cpp
+++ b/Shaders.cpp
@@ -1,5 +1,5 @@
 #include "Shaders.h"
-#include <d3d11.h> 
+#include "D3D11-NoWarn.h" 
 #include "resource.h"
 #include "Globals.h"
 

--- a/Structs.h
+++ b/Structs.h
@@ -2,7 +2,7 @@
 #define STRUCTS_H_
 #pragma once
 
-#include <D3DX11.h>
+#include "D3DX11-NoWarn.h"
 #include <DirectXPackedVector.h>
 #include <list>
 #include <string>

--- a/UAKMCodePanelModule.h
+++ b/UAKMCodePanelModule.h
@@ -2,7 +2,7 @@
 
 #include "FullScreenModule.h"
 #include <unordered_map>
-#include <d3d11.h>
+#include "D3D11-NoWarn.h"
 #include "Texture.h"
 #include "AmbientAudio.h"
 

--- a/UAKMColonelsComputerModule.h
+++ b/UAKMColonelsComputerModule.h
@@ -2,7 +2,7 @@
 
 #include "FullScreenModule.h"
 #include <unordered_map>
-#include <d3d11.h>
+#include "D3D11-NoWarn.h"
 #include "Texture.h"
 
 class CUAKMColonelsComputerModule : public CFullScreenModule

--- a/UAKMColonelsSafeModule.h
+++ b/UAKMColonelsSafeModule.h
@@ -2,7 +2,7 @@
 
 #include "FullScreenModule.h"
 #include <unordered_map>
-#include <d3d11.h>
+#include "D3D11-NoWarn.h"
 #include "Texture.h"
 #include "AmbientAudio.h"
 

--- a/UAKMCrimeLinkModule.h
+++ b/UAKMCrimeLinkModule.h
@@ -2,7 +2,7 @@
 
 #include "FullScreenModule.h"
 #include <unordered_map>
-#include <d3d11.h>
+#include "D3D11-NoWarn.h"
 #include "Texture.h"
 #include "AreaData.h"
 

--- a/UAKMEncodedMessageModule.h
+++ b/UAKMEncodedMessageModule.h
@@ -2,7 +2,7 @@
 
 #include "ModuleBase.h"
 #include <unordered_map>
-#include <d3d11.h>
+#include "D3D11-NoWarn.h"
 #include "Texture.h"
 #include "DXButton.h"
 

--- a/UAKMGRSComputerModule.h
+++ b/UAKMGRSComputerModule.h
@@ -2,7 +2,7 @@
 
 #include "FullScreenModule.h"
 #include <unordered_map>
-#include <d3d11.h>
+#include "D3D11-NoWarn.h"
 #include "Texture.h"
 
 class CUAKMGRSComputerModule : public CFullScreenModule

--- a/UAKMNewsPaperModule.h
+++ b/UAKMNewsPaperModule.h
@@ -2,7 +2,7 @@
 
 #include "ModuleBase.h"
 #include <unordered_map>
-#include <d3d11.h>
+#include "D3D11-NoWarn.h"
 #include "Texture.h"
 #include "DXButton.h"
 

--- a/UAKMSafeModule.h
+++ b/UAKMSafeModule.h
@@ -2,7 +2,7 @@
 
 #include "ModuleBase.h"
 #include <unordered_map>
-#include <d3d11.h>
+#include "D3D11-NoWarn.h"
 #include "Texture.h"
 #include "AmbientAudio.h"
 

--- a/UAKMTornNoteModule.h
+++ b/UAKMTornNoteModule.h
@@ -2,7 +2,7 @@
 
 #include "ModuleBase.h"
 #include <unordered_map>
-#include <d3d11.h>
+#include "D3D11-NoWarn.h"
 #include "Texture.h"
 #include <vector>
 #include "DXText.h"

--- a/UAKMTravelModule.h
+++ b/UAKMTravelModule.h
@@ -2,7 +2,7 @@
 
 #include "ModuleBase.h"
 #include <unordered_map>
-#include <D3D11.h>
+#include "D3D11-NoWarn.h"
 #include "Texture.h"
 #include <list>
 #include <string>

--- a/WinTex.cpp
+++ b/WinTex.cpp
@@ -1,8 +1,8 @@
 #include <windows.h>
 #include <windowsx.h>
-#include <d3d11.h> 
-#include <d3dx11.h>
-#include <d3dx10.h>
+#include "D3D11-NoWarn.h"
+#include "D3DX11-NoWarn.h"
+#include "D3DX10-NoWarn.h"
 #include "LZ.h"
 #include "File.h"
 #include "Utilities.h"

--- a/WinTex.vcxproj
+++ b/WinTex.vcxproj
@@ -267,6 +267,10 @@
     <ClInclude Include="AreaData.h" />
     <ClInclude Include="BIC.h" />
     <ClInclude Include="BinaryData.h" />
+    <ClInclude Include="D3D11-NoWarn.h" />
+    <ClInclude Include="D3DX10-NoWarn.h" />
+    <ClInclude Include="D3DX11-NoWarn.h" />
+    <ClInclude Include="dinput-NoWarn.h" />
     <ClInclude Include="DXMultiColouredText.h" />
     <ClInclude Include="Elevation.h" />
     <ClInclude Include="Hint.h" />

--- a/WinTex.vcxproj.filters
+++ b/WinTex.vcxproj.filters
@@ -43,6 +43,9 @@
     <Filter Include="Structs">
       <UniqueIdentifier>{288b8ec3-396b-41fc-be56-deeb5edb7cbe}</UniqueIdentifier>
     </Filter>
+    <Filter Include="DirectX\Warning Wrappers">
+      <UniqueIdentifier>{69ae6fc5-d3f9-4859-bd05-059168581211}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="DXButton.cpp">
@@ -679,6 +682,18 @@
     </ClInclude>
     <ClInclude Include="DXMultiColouredText.h">
       <Filter>Controls</Filter>
+    </ClInclude>
+    <ClInclude Include="D3D11-NoWarn.h">
+      <Filter>DirectX\Warning Wrappers</Filter>
+    </ClInclude>
+    <ClInclude Include="D3DX11-NoWarn.h">
+      <Filter>DirectX\Warning Wrappers</Filter>
+    </ClInclude>
+    <ClInclude Include="dinput-NoWarn.h">
+      <Filter>DirectX\Warning Wrappers</Filter>
+    </ClInclude>
+    <ClInclude Include="D3DX10-NoWarn.h">
+      <Filter>DirectX\Warning Wrappers</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/dinput-NoWarn.h
+++ b/dinput-NoWarn.h
@@ -1,0 +1,9 @@
+// This file includes dinput.h while disabling warnings
+// in order to cut down on unnecessary backgound noise
+// during compilation
+
+#pragma once
+
+#pragma warning(push, 0)
+#include <dinput.h>
+#pragma warning(pop)


### PR DESCRIPTION
Rather than #include certain DirectX system headers directly, I've added a few wrappers which disable warnings on those headers to stop them from cluttering the build output.

Contributes to #2 